### PR TITLE
Fix expectation for isRequiredPropTypeError()

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -33,7 +33,7 @@ function isRequiredPropTypeError(spy, propName) {
     return false;
   }
 
-  return spy.lastCall.args.find(arg => arg.includes(`Required prop \`${propName}\``)) !== undefined;
+  return spy.lastCall.args.find(arg => arg.includes(`\`${propName}\` is marked as required`)) !== undefined;
 }
 
 describe('<Product />', () => {


### PR DESCRIPTION
As mentioned in the issues comments:

It looks like the syntax of the errors on 'Required' propTypes differs from that of 'Invalid' propTypes, but the test does not reflect this.

Invalid error messages begin:
Invalid prop "prop_name" of type "type_given"

While Required error messages begin:
The prop "prop_name" is marked as required

(These can be seen be viewing the value of spy.lastCall.args[0])

The tests on lines 28 and 36 search for the statements: 'Invalid prop \${propName}`' and 'Required prop `${propName}`' respectively.

Changing the sought statement on line 36 to be: `\`${propName}\` is marked as required` will reflect the given error messages and allow the tests to pass when the expected behavior occurs.